### PR TITLE
Playground Progress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3190,6 +3190,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
+    "bootstrap": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.3.tgz",
+      "integrity": "sha512-o9ppKQioXGqhw8Z7mah6KdTYpNQY//tipnkxppWhPbiSWdD+1raYsnhwEZjkTHYbGee4cVQ0Rx65EhOY/HNLcQ=="
+    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^16.9.8",
     "@types/recoilize": "^0.8.0",
     "babel-loader": "^8.1.0",
+    "bootstrap": "^4.5.3",
     "concurrently": "^5.3.0",
     "dotenv": "^8.2.0",
     "gh-pages": "^3.1.0",

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="stylesheet" href="../src/App.css">
     <link rel="stylesheet" href="../src/index.scss">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/css/bootstrap.min.css" integrity="sha384-TX8t27EcRE3e/ihU7zmQxVncDAy5uIKz4rEkgIXeMed4M0jlfIDPvg6uqKI2xXr2" crossorigin="anonymous">
     <style></style>
     <title>Recoilize</title>
   </head>

--- a/src/Components/Playground/Playground.tsx
+++ b/src/Components/Playground/Playground.tsx
@@ -5,7 +5,7 @@ import { TvShowDetails } from './TvShowDetails';
 
 export default function Playground() {
     return (
-        <div>
+        <div id="playground">
             {/* <h1>Top 10 TV Shows of All Time {isPending && "(loading)"}</h1> */}
             <h1>Top 10 TV Shows of All Time</h1>
             <div className="flex">

--- a/src/Components/Playground/PlaygroundStart.tsx
+++ b/src/Components/Playground/PlaygroundStart.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import {useSetRecoilState} from 'recoil';
+import {playStart} from '../Store/Atoms';
+
+export default function PlaygroundStart() {
+
+  const triggerPlay = useSetRecoilState(playStart)
+
+  return (
+    <div id="PlaygroundStart">
+      <p>This playground, and even this entire webiste, is built with Recoil. Download the Recoilize Dev Tool in the Google Chrome Store and try it out here.</p>
+      <div>
+      <button>Download</button>
+      <button onClick={()=>triggerPlay(true)}>Play</button>
+      </div>
+    </div>
+  )
+}

--- a/src/Components/Playground/PlaygroundStart.tsx
+++ b/src/Components/Playground/PlaygroundStart.tsx
@@ -7,11 +7,12 @@ export default function PlaygroundStart() {
   const triggerPlay = useSetRecoilState(playStart)
 
   return (
-    <div id="PlaygroundStart">
-      <p>This playground, and even this entire webiste, is built with Recoil. Download the Recoilize Dev Tool in the Google Chrome Store and try it out here.</p>
+    <div id="playground-start">
+      <p>This playground, and even this entire webiste, is built using Recoil!</p>
+      <p>Download the Recoilize Dev Tool in the Google Chrome Store and try it out here.</p>
       <div>
-      <button>Download</button>
-      <button onClick={()=>triggerPlay(true)}>Play</button>
+      <button type="button" className="btn btn-primary btn-lg" onClick={()=>window.open('https://chrome.google.com/webstore/detail/recoilize/jhfmmdhbinleghabnblahfjfalfgidik?hl=en')}>Download</button>
+      <button type="button" className="btn btn-secondary btn-lg" onClick={()=>triggerPlay(true)}>Play</button>
       </div>
     </div>
   )

--- a/src/Components/PlaygroundSection.tsx
+++ b/src/Components/PlaygroundSection.tsx
@@ -1,14 +1,20 @@
 import React from 'react';
+import {useRecoilValue} from 'recoil';
 import Playground from './Playground/Playground';
+import PlaygroundStart from './Playground/PlaygroundStart';
+import {playStart} from './Store/Atoms';
 
 export default function PlaygroundSection() {
-    return (
-        <div>
-            <h2 id="hash-ancor" className='section-title-left'>#Playground</h2>
-            <h3 className='section-subtitle'>This is where you can try out our dev tool</h3>
-            <div id='playground-section'>
-                <Playground />
-            </div>
+
+const play = useRecoilValue(playStart)
+
+ 
+return (
+    <div>
+        <h1>Give it a try!</h1>
+        <div className="playground-container">
+        { play ? <Playground /> : <PlaygroundStart />}
         </div>
-    )
+    </div>
+)
 }

--- a/src/Components/PlaygroundSection.tsx
+++ b/src/Components/PlaygroundSection.tsx
@@ -7,12 +7,11 @@ import {playStart} from './Store/Atoms';
 export default function PlaygroundSection() {
 
 const play = useRecoilValue(playStart)
-
  
 return (
-    <div>
+    <div className="main-section" id="playground-section">
         <h1>Give it a try!</h1>
-        <div className="playground-container">
+        <div id="playground-container">
         { play ? <Playground /> : <PlaygroundStart />}
         </div>
     </div>

--- a/src/Components/Store/Atoms.tsx
+++ b/src/Components/Store/Atoms.tsx
@@ -6,3 +6,7 @@ export const id = atom({
   default: 1,
 });
 
+export const playStart = atom({
+  key: 'playStart',
+  default: false,
+});

--- a/src/index.scss
+++ b/src/index.scss
@@ -26,6 +26,14 @@ body {
     flex-direction: column;
 }
 
+.main-section {
+    height: 100vh;
+}
+
+button {
+    width: 125px;
+}
+
 div ul {
     list-style-type: none;
     margin: 0;

--- a/src/styles/Playground.scss
+++ b/src/styles/Playground.scss
@@ -1,0 +1,28 @@
+#playground-container {
+  background-color: white;
+  width: 80vw;
+  height: 80vh;
+  color: black;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+#playground-section {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+#playgound-start {
+  p {
+    width: 50px;
+  }
+}
+
+#playground {
+  height: 100%;
+}


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [X] New feature (change which adds functionality)
- [ ] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The landing page needs a playground for developers to play around with the extension.
## Approach
<!--- How does your change address the problem? -->
Added a playground container which first renders a download and play button. The download button opens up a new tab to the google chrome store so that the user can download recoilize. A state atom was created to keep track of when the user clicks on the play button. When the play button is clicked then the playground renders instead of the two buttons.
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
With Recoil, prop drilling can be avoided entirely as long as proper recoil functions are used. The useRecoilValue and useSetRecoilState were used to read the atom state and then to set the state.
https://recoiljs.org/docs/api-reference/core/useRecoilValue
https://recoiljs.org/docs/api-reference/core/useSetRecoilState
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->
![Screen Shot 2020-10-19 at 10 10 48 AM](https://user-images.githubusercontent.com/25422789/96489214-fdefac00-11f3-11eb-9997-e907a21cf81a.png)