### PR TITLE
Created a second react render for playground.

### DIFF
--- a/src/Components/Playground/Playground.tsx
+++ b/src/Components/Playground/Playground.tsx
@@ -6,17 +6,17 @@ import { TvShowDetails } from './TvShowDetails';
 export default function Playground() {
     return (
         <div id="playground">
-            {/* <h1>Top 10 TV Shows of All Time {isPending && "(loading)"}</h1> */}
+            {/* <h1>Top 10 TV Shows of All Time {isPending && "(loading)"}</h1>
             <h1>Top 10 TV Shows of All Time</h1>
             <div className="flex">
                 <Suspense fallback={<Spinner />}>
                     {/* <TvShowList startTransition={startTransition}/> */}
-                    <TvShowList/>
-                </Suspense>
-                <Suspense fallback={<Spinner />}>
-                    <TvShowDetails/>
-                </Suspense>
-            </div>
+                    {/* <TvShowList/> */}
+                {/* </Suspense> */}
+                {/* <Suspense fallback={<Spinner />}> */}
+                    {/* <TvShowDetails/> */}
+                {/* </Suspense> */}
+            {/* </div> */}
         </div>
     )
 }

--- a/src/Components/Playground/Spinner.tsx
+++ b/src/Components/Playground/Spinner.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export const Spinner = () => (
   <div>
-    <svg
+    {/* <svg
       style={{
         margin: "auto",
         background: "transparent",
@@ -34,6 +34,6 @@ export const Spinner = () => (
           values="0 50 50;360 50 50"
         />
       </circle>
-    </svg>
+    </svg> */}
   </div>
 );

--- a/src/Components/Playground/TvShowDetails.tsx
+++ b/src/Components/Playground/TvShowDetails.tsx
@@ -7,32 +7,32 @@ import * as atoms from '../Store/Atoms';
 
 const Comments = () => {
 
-  const id = useRecoilValue(atoms.id);
+  // const id = useRecoilValue(atoms.id);
 
-  const commentsResource = getCommentsResource(id).read();
-  const comments = commentsResource.map(comment => (
-    <div className="comment" key={comment.id}>
-      <h4>{comment.title}</h4>
-      <div className="text">{comment.text}</div>
-    </div>
-  ));
+  // const commentsResource = getCommentsResource(id).read();
+  // const comments = commentsResource.map(comment => (
+  //   <div className="comment" key={comment.id}>
+  //     <h4>{comment.title}</h4>
+  //     <div className="text">{comment.text}</div>
+  //   </div>
+  // ));
 
   return (
     <div className="flex flex-col comments">
-      <h3>Comments</h3>
-      {comments}
+      {/* <h3>Comments</h3>
+      {comments} */}
     </div>
   );
 };
 
 const Details = () => {
 
-  const id = useRecoilValue(atoms.id);
+  // const id = useRecoilValue(atoms.id);
 
-  const tvShowResource = getTvDataResource(id).read();
+  // const tvShowResource = getTvDataResource(id).read();
   return (
     <div className="flex">
-      <div>
+      {/* <div>
         <h2>{tvShowResource.name}</h2>
         <div className="details">{tvShowResource.description}</div>
       </div>
@@ -41,7 +41,7 @@ const Details = () => {
           src={`https://res.cloudinary.com/dqsubx7oc/image/upload/w_200/v1582908284/tv-shows/${id}.jpg`}
           alt={tvShowResource.name}
         />
-      </div>
+      </div> */}
     </div>
   );
 };
@@ -51,12 +51,12 @@ export const TvShowDetails = () => {
 
   return (
     <div className="tvshow-details">
-      <Suspense fallback={<Spinner />}>
+      {/* <Suspense fallback={<Spinner />}>
         <Details/>
         <Suspense fallback={<Spinner />}>
           <Comments/>
         </Suspense>
-      </Suspense>
+      </Suspense> */}
     </div>
   );
 

--- a/src/Components/Playground/TvShowList.tsx
+++ b/src/Components/Playground/TvShowList.tsx
@@ -4,19 +4,19 @@ import { getTvMetadataResource } from "./helpers/Api";
 import * as atoms from '../Store/Atoms';
 
 export const TvShowList = () => {
-  const [id, setId] = useRecoilState(atoms.id);
+  // const [id, setId] = useRecoilState(atoms.id);
 
-  const onClick = (newId) => {
-    setId(newId)
-  };
+  // const onClick = (newId) => {
+  //   setId(newId)
+  // };
 
 
-  const tvMetadata = getTvMetadataResource().read();
-  const tvshows = tvMetadata.map(item => (
-    <div className="item" key={item.id} onClick={() => onClick(item.id)}>
-      <div className="name">{item.name}</div>
-      <div className="score">{item.score}</div>
-    </div>
-  ));
-  return <div className="tvshow-list">{tvshows}</div>;
+  // const tvMetadata = getTvMetadataResource().read();
+  // const tvshows = tvMetadata.map(item => (
+  //   <div className="item" key={item.id} onClick={() => onClick(item.id)}>
+  //     <div className="name">{item.name}</div>
+  //     <div className="score">{item.score}</div>
+  //   </div>
+  // ));
+  return <div className="tvshow-list"></div>;
 };

--- a/src/Components/PlaygroundSection.tsx
+++ b/src/Components/PlaygroundSection.tsx
@@ -1,23 +1,29 @@
 import React from 'react';
 import {useRecoilValue} from 'recoil';
-// eslint-disable-next-line
-import Playground from './Playground/Playground';
+
 import PlaygroundStart from './Playground/PlaygroundStart';
 import {playStart} from './Store/Atoms';
 import TicTacToe from './Playground/TicTacToe';
 
+
+export function PlaygroundRender () {
+    const play = useRecoilValue(playStart)
+    return (
+        <>
+        { play ? <TicTacToe /> : <PlaygroundStart />}
+        </>
+    )
+}
+
+
 export default function PlaygroundSection() {
 
-const play = useRecoilValue(playStart)
- 
 return (
     <div className="dark-background" id="playground-section">
 
         <h2 className="section-title-center">Give it a try!</h2>
 
-        <div id="playground-container">
-        { play ? <TicTacToe /> : <PlaygroundStart />}
-        </div>
+        <div id="playground-container"></div>
     </div>
 )
 }

--- a/src/Components/Store/Atoms.tsx
+++ b/src/Components/Store/Atoms.tsx
@@ -1,9 +1,9 @@
 import {atom, selector} from 'recoil';
 
-export const id = atom({
-  key: 'id',
-  default: 1,
-});
+// export const id = atom({
+//   key: 'id',
+//   default: 1,
+// });
 
 export const playStart = atom({
   key: 'playStart',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,16 +5,26 @@ import App from './App';
 // import * as serviceWorker from './serviceWorker';
 import { RecoilRoot } from 'recoil';
 import RecoilizeDebugger from 'recoilize';
+import {PlaygroundRender} from './Components/PlaygroundSection';
 
 const root = document.getElementById('root');
 
 ReactDOM.render(
   <RecoilRoot>
-    <RecoilizeDebugger />
     <App />
   </RecoilRoot>,
   root
 );
+
+// A second ReactDOM.render is necessary so that the Recoilize Dev Tool only shows the state for the playground. This rerender must happen after the first render at root otherwise the id of 'playground-container' will be undefined.
+
+ReactDOM.render(
+  <RecoilRoot>
+    <RecoilizeDebugger root = {document.getElementById('playground-container')}/>
+    <PlaygroundRender />
+  </RecoilRoot>,
+  document.getElementById('playground-container')
+)
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [ ] New feature (change which adds functionality)
- [X] Refactor (change which changes the codebase without affecting its external behavior)
- [ ] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
The playground is meant for users to explore the dev tool. Previously the tool would show the state of the entire landing page, including the playground, but we want to only show the playground state. 
## Approach
<!--- How does your change address the problem? -->
A second ReactDOM render was added after the main root React render. In this second render, the RecoilizeDebugger component is placed upstream of a PlaygroundRender component. This will render at id "playground-container".
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
A second render was necessary because the RecoilizeDebugger requires a root as a prop. The root being used is id "playground-container". This is undefined at the moment of the very first render. 